### PR TITLE
release: run tag/version check on all tag refs; align Python support …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,12 @@ jobs:
       # A tag is the only thing that names the release, but the versions live
       # in setup.py. Without this, tagging v0.2.0 would happily publish 0.1.0.
       - name: Verify tag matches built version
-        if: github.event_name == 'push'
+        # Any tag ref, regardless of trigger: a workflow_dispatch re-run on a
+        # tag with dry-run=false reaches `publish` too, and skipping the check
+        # there would let a stale setup.py version ship under a newer tag
+        # (worse: skip-existing would silently skip the upload and the GitHub
+        # Release would carry the old artifacts under the new tag name).
+        if: github.ref_type == 'tag'
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |

--- a/compat/setup.py
+++ b/compat/setup.py
@@ -150,8 +150,16 @@ Source: https://github.com/databrickslabs/sdp-meta
     # explicitly ``import dlt_meta`` in their notebooks.
     cmdclass={"bdist_wheel": bdist_wheel_with_pth_file},
     entry_points={"group_1": "run=dlt_meta:main"},
+    # Must stay identical to the primary package's version classifiers so both
+    # advertise the same interpreters; tests/test_packaging_metadata.py enforces it.
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Development Status :: 7 - Inactive",  # Indicates deprecated
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,13 @@ MCP_REQUIREMENTS = ["mcp>=1.0,<2.0"]
 setup(
     name="databricks-labs-sdp-meta",
     version="0.1.0",
-    python_requires=">=3.8",
+    # Ceiling matches compat/setup.py: the pyspark 3.5.5 stack this framework
+    # runs against is incompatible with Python 3.13+ (pickle/cloudpickle
+    # changes; see GETTING_STARTED.md prerequisites). Keeping both packages'
+    # ceilings identical means `pip install dlt-meta` and
+    # `pip install databricks-labs-sdp-meta` succeed/fail on the same
+    # interpreters. Re-evaluate when pyspark ships a 3.13-compatible release.
+    python_requires=">=3.8, <3.13",
     # No ``setup_requires``: it makes setuptools fetch build deps from PyPI
     # mid-build, which breaks the release workflow's ``--no-isolation`` build
     # (nothing may be fetched at build time). Build deps are supplied by
@@ -147,8 +153,16 @@ setup(
             "stage_conf=databricks.labs.sdp_meta.stage_conf:main",
         ],
     },
+    # Per-version classifiers must cover exactly the range declared in
+    # ``python_requires`` above; tests/test_packaging_metadata.py enforces it.
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Testing",
         "Intended Audience :: Developers",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,103 @@
+"""Tests that the two distributions advertise the same Python support.
+
+The supported interpreter range is written in three places: ``python_requires``
+and the version classifiers in setup.py, plus the same pair in compat/setup.py.
+pip only enforces ``python_requires``, so a stale classifier list or a compat
+wrapper that drifts from the package it forwards to would ship unnoticed.
+
+The setup.py files are read with ``ast`` rather than imported -- executing them
+at test time would need setuptools' build context and would run the README
+rewriting in the primary setup.py for no benefit.
+"""
+import ast
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRIMARY_SETUP = REPO_ROOT / "setup.py"
+COMPAT_SETUP = REPO_ROOT / "compat" / "setup.py"
+
+# ">=3.8, <3.13" -- an inclusive floor and an exclusive ceiling, both 3.x.
+PYTHON_REQUIRES_RE = re.compile(r"^>=3\.(\d+),\s*<3\.(\d+)$")
+VERSION_CLASSIFIER_RE = re.compile(r"^Programming Language :: Python :: 3\.(\d+)$")
+
+
+def _setup_kwargs(setup_py: Path) -> dict:
+    """Return the literal keyword arguments of the ``setup()`` call."""
+    tree = ast.parse(setup_py.read_text(encoding="utf-8"), str(setup_py))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup":
+            kwargs = {}
+            for keyword in node.keywords:
+                if keyword.arg is None:
+                    continue
+                try:
+                    kwargs[keyword.arg] = ast.literal_eval(keyword.value)
+                except ValueError:
+                    # Computed values such as long_description; not under test.
+                    continue
+            return kwargs
+    raise AssertionError(f"no setup() call found in {setup_py}")
+
+
+class PythonSupportMetadataTests(unittest.TestCase):
+
+    def setUp(self):
+        self.primary = _setup_kwargs(PRIMARY_SETUP)
+        self.compat = _setup_kwargs(COMPAT_SETUP)
+
+    def _declared_range(self, kwargs: dict, label: str) -> range:
+        """Minor versions covered by ``python_requires``, e.g. range(8, 13)."""
+        python_requires = kwargs.get("python_requires")
+        self.assertIsNotNone(python_requires, f"{label} declares no python_requires")
+        match = PYTHON_REQUIRES_RE.match(python_requires)
+        self.assertIsNotNone(
+            match,
+            f"{label} python_requires={python_requires!r} is not of the form "
+            "'>=3.X, <3.Y'; update PYTHON_REQUIRES_RE if this is intentional",
+        )
+        floor, ceiling = int(match.group(1)), int(match.group(2))
+        self.assertLess(floor, ceiling, f"{label} declares an empty version range")
+        return range(floor, ceiling)
+
+    def _version_classifiers(self, kwargs: dict) -> set:
+        return {
+            int(match.group(1))
+            for match in (
+                VERSION_CLASSIFIER_RE.match(c) for c in kwargs.get("classifiers", [])
+            )
+            if match
+        }
+
+    def test_both_distributions_declare_the_same_python_requires(self):
+        self.assertEqual(
+            self.primary.get("python_requires"),
+            self.compat.get("python_requires"),
+            "setup.py and compat/setup.py must accept the same interpreters -- the "
+            "compat wrapper depends on the primary package, so a wider floor or "
+            "ceiling there installs on interpreters its dependency rejects",
+        )
+
+    def test_version_classifiers_cover_the_declared_range(self):
+        for label, kwargs in (("setup.py", self.primary), ("compat/setup.py", self.compat)):
+            with self.subTest(setup=label):
+                expected = set(self._declared_range(kwargs, label))
+                self.assertEqual(
+                    self._version_classifiers(kwargs),
+                    expected,
+                    f"{label} version classifiers do not match python_requires; "
+                    "PyPI's Programming Language facet would advertise the wrong "
+                    "interpreters",
+                )
+
+    def test_base_python3_classifiers_are_present(self):
+        for label, kwargs in (("setup.py", self.primary), ("compat/setup.py", self.compat)):
+            with self.subTest(setup=label):
+                classifiers = kwargs.get("classifiers", [])
+                self.assertIn("Programming Language :: Python :: 3", classifiers)
+                self.assertIn("Programming Language :: Python :: 3 :: Only", classifiers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Pre-tag fixes for v0.1.0.

- release.yml: gate "Verify tag matches built version" on github.ref_type == 'tag' instead of the push event. A workflow_dispatch re-run on a tag with dry-run=false reaches publish without the check; a stale setup.py version would build under the newer tag, skip-existing would silently skip the PyPI upload, and the GitHub Release would carry old artifacts under the new tag name.

- setup.py: cap python_requires at <3.13 to match compat/setup.py (pyspark 3.5.5 stack is incompatible with 3.13+). Previously `pip install dlt-meta` was refused on 3.13 while `pip install databricks-labs-sdp-meta` succeeded.

- setup.py, compat/setup.py: add per-version classifiers (3.8-3.12, plus "3 :: Only") so PyPI advertises the supported interpreters; pip only enforces python_requires.

- tests/test_packaging_metadata.py: new stdlib-only test that AST-parses both setup.py files and asserts python_requires agree across the two distributions and the version classifiers cover exactly the declared range, so the metadata can't drift unnoticed.