### PR TITLE
Fix onboard job's default dependency to the real PyPI name

### DIFF
--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -722,7 +722,7 @@ class SDPMeta:
                 }
             )
         named_parameters = self._get_onboarding_named_parameters(cmd)
-        sdp_meta_dependency = cmd.sdp_meta_dependency or f"sdp-meta=={self.version}"
+        sdp_meta_dependency = cmd.sdp_meta_dependency or f"databricks-labs-sdp-meta=={self.version}"
         sdp_meta_environments = [
             jobs.JobEnvironment(
                 environment_key="sdp_meta_cli_env",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,6 +190,76 @@ class CliTests(unittest.TestCase):
         )
 
     @patch("databricks.labs.sdp_meta.cli.WorkspaceClient")
+    def test_create_onboarding_job_serverless_defaults_to_pypi_dependency(self, mock_workspace_client):
+        mock_workspace_client.jobs.create.return_value = MagicMock(job_id="job_id")
+        sdp_meta = SDPMeta(mock_workspace_client)
+        cmd = OnboardCommand(
+            onboarding_file_path=self.onboarding_file_path,
+            onboarding_files_dir_path="tests/resources/",
+            onboard_layer="bronze",
+            env="dev",
+            import_author="John Doe",
+            version="1.0",
+            cloud="aws",
+            sdp_meta_schema="sdp_meta",
+            bronze_dataflowspec_path="tests/resources/bronze_dataflowspec",
+            silver_dataflowspec_path="tests/resources/silver_dataflowspec",
+            uc_enabled=True,
+            uc_catalog_name="uc_catalog",
+            uc_volume_path="/Volumes/uc_catalog/sdp_meta/files",
+            overwrite=True,
+            bronze_dataflowspec_table="bronze_dataflowspec",
+            silver_dataflowspec_table="silver_dataflowspec",
+        )
+
+        sdp_meta.create_onnboarding_job(cmd)
+
+        # Without ``sdp_meta_dependency`` the fallback must be the real PyPI
+        # distribution (``databricks-labs-sdp-meta``), not the Labs project
+        # name ``sdp-meta``, which does not exist on PyPI (issue #408).
+        job_kwargs = mock_workspace_client.jobs.create.call_args.kwargs
+        self.assertEqual(
+            job_kwargs["environments"][0].spec.dependencies,
+            [f"databricks-labs-sdp-meta=={__version__}"],
+        )
+
+    @patch("databricks.labs.sdp_meta.cli.WorkspaceClient")
+    def test_create_onboarding_job_classic_defaults_to_pypi_library(self, mock_workspace_client):
+        mock_workspace_client.jobs.create.return_value = MagicMock(job_id="job_id")
+        sdp_meta = SDPMeta(mock_workspace_client)
+        cmd = OnboardCommand(
+            onboarding_file_path=self.onboarding_file_path,
+            onboarding_files_dir_path="tests/resources/",
+            onboard_layer="bronze",
+            env="dev",
+            import_author="John Doe",
+            version="1.0",
+            cloud="aws",
+            dbr_version="15.4.x-scala2.12",
+            serverless=False,
+            sdp_meta_schema="sdp_meta",
+            bronze_dataflowspec_path="tests/resources/bronze_dataflowspec",
+            silver_dataflowspec_path="tests/resources/silver_dataflowspec",
+            uc_enabled=True,
+            uc_catalog_name="uc_catalog",
+            uc_volume_path="/Volumes/uc_catalog/sdp_meta/files",
+            overwrite=True,
+            bronze_dataflowspec_table="bronze_dataflowspec",
+            silver_dataflowspec_table="silver_dataflowspec",
+        )
+
+        sdp_meta.create_onnboarding_job(cmd)
+
+        # Classic clusters install via ``PythonPyPiLibrary`` and must use the
+        # same PyPI fallback as the serverless path (issue #408).
+        job_kwargs = mock_workspace_client.jobs.create.call_args.kwargs
+        task_libraries = job_kwargs["tasks"][0].libraries
+        self.assertEqual(
+            task_libraries[0].pypi.package,
+            f"databricks-labs-sdp-meta=={__version__}",
+        )
+
+    @patch("databricks.labs.sdp_meta.cli.WorkspaceClient")
     def test_install_folder(self, mock_workspace_client):
         sdp_meta = SDPMeta(mock_workspace_client)
         sdp_meta._wsi = mock_workspace_client.return_value


### PR DESCRIPTION
create_onnboarding_job fell back to sdp-meta==<version>, which does not exist on PyPI, so serverless and classic onboard jobs created without a wheel flag failed during environment install. Use
databricks-labs-sdp-meta==<version>, matching the deploy path's existing fallback.

Fixes #408