### PR TITLE
Add system_sequence_by support for bitemporal AUTO CDC flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- **Bitemporal AUTO CDC support (Beta)**: `cdc_apply_changes` accepts `scd_type: "bitemporal"` with a new `system_sequence_by` attribute, forwarded to `create_auto_cdc_flow` to track history across both business time (`sequence_by`) and system time. The attribute is only sent when configured, so existing SCD 1/2 flows are unaffected on runtimes that predate the parameter. [Issue #359](https://github.com/databrickslabs/sdp-meta/issues/359)
+
 ## [v0.1.0]
 ### ⚠️ Breaking Changes
 - **Project rename `dlt-meta` → `sdp-meta`** to align with the Lakeflow Spark Declarative Pipelines product naming. This affects the PyPI package, CLI command, Python import path, source layout, and main class name. A backward-compatibility wrapper is published so existing installations keep working with a deprecation warning. [PR](https://github.com/databrickslabs/sdp-meta/pull/289)

--- a/docs/docs/guides/cdc.md
+++ b/docs/docs/guides/cdc.md
@@ -11,6 +11,7 @@ Use this pattern when your source system emits a CDC stream with insert, update,
 Supported SCD types:
 - **Type 1** (`scd_type: 1`) — overwrite the existing row; no history retained
 - **Type 2** (`scd_type: 2`) — retain full row history with validity timestamps
+- **Bitemporal** (`scd_type: bitemporal`, Beta) — track history across both business time (`sequence_by`) and system time (`system_sequence_by`), so the table can answer both "what was true at T" and "what did we know at T". Requires `system_sequence_by` and a runtime channel where bitemporal AUTO CDC is available.
 
 ## `bronze_cdc_apply_changes` configuration
 
@@ -30,11 +31,30 @@ Supported SCD types:
 |---|---|---|---|
 | `keys` | array of strings | Yes | Primary key columns |
 | `sequence_by` | string | Yes | Column(s) used to order events and determine the most recent |
-| `scd_type` | string | Yes | `1` for overwrite or `2` for history |
+| `scd_type` | string | Yes | `1` for overwrite, `2` for history, or `bitemporal` (Beta) for business-time plus system-time history |
 | `apply_as_deletes` | string | No | SQL expression identifying delete events |
 | `except_column_list` | array of strings | No | Columns to exclude from the target table |
 | `track_history_column_list` | array of strings | No | (Type 2 only) Columns whose changes trigger a new history row |
 | `track_history_except_column_list` | array of strings | No | (Type 2 only) Columns to exclude from history tracking |
+| `system_sequence_by` | string | Bitemporal only | Column holding the system time at which each CDC event became known (e.g. an ingestion timestamp). Required with `scd_type: bitemporal`, rejected otherwise. Must be a sortable data type. |
+
+### Bitemporal example (Beta)
+
+```json
+{
+  "bronze_cdc_apply_changes": {
+    "keys": ["customer_id"],
+    "sequence_by": "event_ts",
+    "scd_type": "bitemporal",
+    "system_sequence_by": "ingest_ts",
+    "except_column_list": ["Op", "_rescued_data"]
+  }
+}
+```
+
+:::note
+Bitemporal AUTO CDC is a Beta runtime feature. `system_sequence_by` is only sent to `create_auto_cdc_flow` when configured, so existing SCD 1/2 flows are unaffected on runtime channels that predate the parameter.
+:::
 
 ## `silver_cdc_apply_changes` configuration
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -115,7 +115,14 @@
 
         The workflow is a minimal 3-task fan-in: `setup_sdp_meta_pipeline_spec → sdp-meta-pipeline → validate_results` (no A2 incremental step, no publish-events step). The `sdp-meta-pipeline` task runs **one** combined Lakeflow Spark Declarative Pipeline configured with `layer=bronze_silver` (groups `bronze.group=A1` and `silver.group=A1`), so all three regional bronze CDC tables AND the unified silver multi-source AUTO CDC merge execute inside a single observable DLT flow graph — matching Stage 11 of the interactive demo notebook and the standalone `demo/launch_multi_source_cdc_demo.py`. Seed data lives under [`integration_tests/resources/data/multi_source_cdc/`](resources/data/multi_source_cdc/) and the onboarding template is [`integration_tests/conf/json/multi-source-cdc-onboarding.template`](conf/json/multi-source-cdc-onboarding.template) (YAML sibling: [`conf/yml/multi-source-cdc-onboarding.template.yml`](conf/yml/multi-source-cdc-onboarding.template.yml)).
 
-    > **Tip:** any of the five sources (`cloudfiles`, `eventhub`, `kafka`, `snapshot`, `multi_source_cdc`) accepts ```--onboarding_file_format=yaml``` to run the same test against the YAML onboarding spec.
+    - 9f. Run the command for **bitemporal** (issue [#359](https://github.com/databrickslabs/sdp-meta/issues/359))
+        ```commandline
+        python integration_tests/run_integration_tests.py --source=bitemporal --uc_catalog_name=<<uc catalog name>> --profile=<<DEFAULT>>
+        ```
+
+        End-to-end checks for bitemporal AUTO CDC (`scd_type: bitemporal` + `system_sequence_by`). Seeds one bronze CDC source whose 4 events include a **late-arriving correction** (business time 11:30, ingested at 14:00), then runs a bronze pipeline whose `bronze_cdc_apply_changes` block is stored as bitemporal. The validator asserts the four generated bitemporal columns (`__START_AT`/`__END_AT`/`__SYSTEM_START_AT`/`__SYSTEM_END_AT`), the version-row total, the current rows on both time axes, an as-of-system-time query that returns the *pre-correction* belief, and the rewritten business-history row the late event produced. Workflow is the minimal 3-task shape: `setup_sdp_meta_pipeline_spec → bronze_dlt_pipeline → validate_results`. Seed data lives under [`integration_tests/resources/data/bitemporal/`](resources/data/bitemporal/) and the onboarding template is [`integration_tests/conf/json/bitemporal-onboarding.template`](conf/json/bitemporal-onboarding.template) (YAML sibling: [`conf/yml/bitemporal-onboarding.template.yml`](conf/yml/bitemporal-onboarding.template.yml)). Requires a runtime channel where bitemporal AUTO CDC (Beta) is available.
+
+    > **Tip:** any of the six sources (`cloudfiles`, `eventhub`, `kafka`, `snapshot`, `multi_source_cdc`, `bitemporal`) accepts ```--onboarding_file_format=yaml``` to run the same test against the YAML onboarding spec.
 
 
 10. Once finished integration output file will be copied locally to
@@ -343,6 +350,7 @@ The dataclass defaults all point at the `/json/` tree. When the runner is starte
 | `integration_tests/conf/json/kafka-onboarding.template`      | `integration_tests/conf/yml/kafka-onboarding.template.yml`      |
 | `integration_tests/conf/json/snapshot-onboarding.template`   | `integration_tests/conf/yml/snapshot-onboarding.template.yml`   |
 | `integration_tests/conf/json/multi-source-cdc-onboarding.template` | `integration_tests/conf/yml/multi-source-cdc-onboarding.template.yml` |
+| `integration_tests/conf/json/bitemporal-onboarding.template` | `integration_tests/conf/yml/bitemporal-onboarding.template.yml` |
 | `integration_tests/conf/json/onboarding.json` *(generated)*  | `integration_tests/conf/yml/onboarding.yml` *(generated)*       |
 | `integration_tests/conf/json/onboarding_A2.json` *(generated)* | `integration_tests/conf/yml/onboarding_A2.yml` *(generated)*  |
 

--- a/integration_tests/conf/json/bitemporal-onboarding.template
+++ b/integration_tests/conf/json/bitemporal-onboarding.template
@@ -1,0 +1,31 @@
+[
+   {
+      "data_flow_id": "bt-it-100",
+      "data_flow_group": "A1",
+      "source_system": "BitemporalCDC",
+      "source_format": "cloudFiles",
+      "source_details": {
+         "source_database": "APP",
+         "source_table": "CUSTOMERS_CDC",
+         "source_path_it": "{uc_volume_path}/integration_tests/resources/data/bitemporal/customers_cdc",
+         "source_schema_path": "{uc_volume_path}/integration_tests/resources/data/bitemporal/ddl/customers_cdc.ddl"
+      },
+      "bronze_catalog_it": "{uc_catalog_name}",
+      "bronze_database_it": "{bronze_schema}",
+      "bronze_table": "customers_bitemporal",
+      "bronze_reader_options": {
+         "cloudFiles.format": "json",
+         "cloudFiles.rescuedDataColumn": "_rescued_data"
+      },
+      "bronze_cdc_apply_changes": {
+         "keys": ["id"],
+         "sequence_by": "event_ts",
+         "scd_type": "bitemporal",
+         "system_sequence_by": "ingest_ts",
+         "except_column_list": ["operation", "_rescued_data"]
+      },
+      "bronze_table_properties": {
+         "pipelines.autoOptimize.managed": "true"
+      }
+   }
+]

--- a/integration_tests/conf/yml/bitemporal-onboarding.template.yml
+++ b/integration_tests/conf/yml/bitemporal-onboarding.template.yml
@@ -1,0 +1,26 @@
+- data_flow_id: "bt-it-100"
+  data_flow_group: "A1"
+  source_system: "BitemporalCDC"
+  source_format: "cloudFiles"
+  source_details:
+    source_database: "APP"
+    source_table: "CUSTOMERS_CDC"
+    source_path_it: "{uc_volume_path}/integration_tests/resources/data/bitemporal/customers_cdc"
+    source_schema_path: "{uc_volume_path}/integration_tests/resources/data/bitemporal/ddl/customers_cdc.ddl"
+  bronze_catalog_it: "{uc_catalog_name}"
+  bronze_database_it: "{bronze_schema}"
+  bronze_table: "customers_bitemporal"
+  bronze_reader_options:
+    cloudFiles.format: "json"
+    cloudFiles.rescuedDataColumn: "_rescued_data"
+  bronze_cdc_apply_changes:
+    keys:
+      - "id"
+    sequence_by: "event_ts"
+    scd_type: "bitemporal"
+    system_sequence_by: "ingest_ts"
+    except_column_list:
+      - "operation"
+      - "_rescued_data"
+  bronze_table_properties:
+    pipelines.autoOptimize.managed: "true"

--- a/integration_tests/notebooks/bitemporal_runners/init_sdp_meta_pipeline.py
+++ b/integration_tests/notebooks/bitemporal_runners/init_sdp_meta_pipeline.py
@@ -1,0 +1,10 @@
+# Databricks notebook source
+sdp_meta_whl = spark.conf.get("sdp_meta_whl")
+%pip install $sdp_meta_whl # noqa : E999
+
+# COMMAND ----------
+
+layer = spark.conf.get("layer", None)
+
+from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline
+DataflowPipeline.invoke_dlt_pipeline(spark, layer)

--- a/integration_tests/notebooks/bitemporal_runners/validate.py
+++ b/integration_tests/notebooks/bitemporal_runners/validate.py
@@ -1,0 +1,126 @@
+# Databricks notebook source
+"""Integration test validation for bitemporal AUTO CDC (issue #359).
+
+The seed file ``integration_tests/resources/data/bitemporal/customers_cdc/``
+carries 4 CDC events for 2 keys, including one LATE-ARRIVING correction:
+``c-002`` is corrected at business time 11:30 but only ingested at 14:00.
+With ``scd_type: bitemporal`` + ``system_sequence_by: ingest_ts`` the
+target must track validity on two time axes (``__START_AT``/``__END_AT``
+for business time from ``sequence_by``, ``__SYSTEM_START_AT``/
+``__SYSTEM_END_AT`` for system time from ``system_sequence_by``).
+
+Assertions:
+
+1. The target schema carries all four bitemporal columns.
+2. Exactly 6 version rows exist (3 per key: superseded belief, corrected
+   history, current).
+3. Exactly 2 rows are current on both axes, and they are the latest
+   business-time values (``alice_v2``, ``bob_corrected``).
+4. An as-of-system-time query at 13:00 still returns the UNCORRECTED
+   belief for ``c-002`` (``bob``) — what the system believed before the
+   late event arrived at 14:00.
+5. The corrected history row exists: ``c-002`` valid in business time
+   [11:00 -> 11:30), known only from system time 14:00 onward.
+"""
+
+import pandas as pd
+
+run_id = dbutils.widgets.get("run_id")
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
+uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
+bronze_schema = dbutils.widgets.get("bronze_schema")
+silver_schema = dbutils.widgets.get("silver_schema")
+output_file_path = dbutils.widgets.get("output_file_path")
+log_list = []
+
+log_list.append("Completed Bronze Lakeflow Spark Declarative Pipeline (bitemporal AUTO CDC).")
+
+
+def _qualify(schema, table):
+    return (
+        f"{uc_catalog_name}.{schema}.{table}"
+        if uc_enabled
+        else f"{schema}.{table}"
+    )
+
+
+target = _qualify(bronze_schema, "customers_bitemporal")
+
+log_list.append(f"Validating bitemporal schema of {target}...")
+columns = {f.name for f in spark.table(target).schema.fields}
+expected_bt_columns = {"__START_AT", "__END_AT", "__SYSTEM_START_AT", "__SYSTEM_END_AT"}
+try:
+    assert expected_bt_columns.issubset(columns)
+    log_list.append(f"Bitemporal columns {sorted(expected_bt_columns)} present. Passed!")
+except AssertionError:
+    log_list.append(
+        f"Bitemporal columns missing. Expected: {sorted(expected_bt_columns)} "
+        f"Actual: {sorted(columns)}. Failed!"
+    )
+
+log_list.append("Validating total version-row count...")
+total = spark.sql(f"SELECT count(*) AS cnt FROM {target}").collect()[0].cnt
+try:
+    assert int(total) == 6
+    log_list.append(f"Total version rows. Expected: 6 Actual: {total}. Passed!")
+except AssertionError:
+    log_list.append(f"Total version rows. Expected: 6 Actual: {total}. Failed!")
+
+log_list.append("Validating current rows (both time axes open)...")
+current_names = {
+    row["name"]
+    for row in spark.sql(
+        f"SELECT name FROM {target} "
+        "WHERE __END_AT IS NULL AND __SYSTEM_END_AT IS NULL"
+    ).collect()
+}
+expected_current = {"alice_v2", "bob_corrected"}
+try:
+    assert current_names == expected_current
+    log_list.append(f"Current rows. Expected: {sorted(expected_current)} Passed!")
+except AssertionError:
+    log_list.append(
+        f"Current rows MISMATCH. Expected: {sorted(expected_current)} "
+        f"Actual: {sorted(current_names)}. Failed!"
+    )
+
+log_list.append("Validating as-of-system-time query (pre-correction belief)...")
+belief_rows = spark.sql(
+    f"SELECT name FROM {target} "
+    "WHERE id = 'c-002' "
+    "AND __SYSTEM_START_AT <= TIMESTAMP'2024-01-15 13:00:00+00:00' "
+    "AND (__SYSTEM_END_AT IS NULL OR __SYSTEM_END_AT > TIMESTAMP'2024-01-15 13:00:00+00:00') "
+    "AND __END_AT IS NULL"
+).collect()
+try:
+    assert len(belief_rows) == 1 and belief_rows[0]["name"] == "bob"
+    log_list.append(
+        "As-of system time 13:00 the believed-current value for c-002 is 'bob'. Passed!"
+    )
+except AssertionError:
+    log_list.append(
+        f"As-of system time 13:00 belief for c-002. Expected: ['bob'] "
+        f"Actual: {[r['name'] for r in belief_rows]}. Failed!"
+    )
+
+log_list.append("Validating late-arriving correction rewrote business history...")
+corrected = spark.sql(
+    f"SELECT count(*) AS cnt FROM {target} "
+    "WHERE id = 'c-002' AND name = 'bob' "
+    "AND __START_AT = TIMESTAMP'2024-01-15 11:00:00+00:00' "
+    "AND __END_AT = TIMESTAMP'2024-01-15 11:30:00+00:00' "
+    "AND __SYSTEM_START_AT = TIMESTAMP'2024-01-15 14:00:00+00:00' "
+    "AND __SYSTEM_END_AT IS NULL"
+).collect()[0].cnt
+try:
+    assert int(corrected) == 1
+    log_list.append(
+        "Corrected history row (c-002 business [11:00 -> 11:30) known from 14:00). Passed!"
+    )
+except AssertionError:
+    log_list.append(
+        f"Corrected history row for c-002. Expected: 1 Actual: {corrected}. Failed!"
+    )
+
+pd_df = pd.DataFrame(log_list)
+pd_df.to_csv(output_file_path)

--- a/integration_tests/resources/data/bitemporal/customers_cdc/customers_cdc_2024_01.json
+++ b/integration_tests/resources/data/bitemporal/customers_cdc/customers_cdc_2024_01.json
@@ -1,0 +1,4 @@
+{"id":"c-001","name":"alice","operation":"APPEND","event_ts":"2024-01-15T10:00:00.000Z","ingest_ts":"2024-01-15T10:05:00.000Z"}
+{"id":"c-001","name":"alice_v2","operation":"UPDATE","event_ts":"2024-01-15T12:00:00.000Z","ingest_ts":"2024-01-15T12:05:00.000Z"}
+{"id":"c-002","name":"bob","operation":"APPEND","event_ts":"2024-01-15T11:00:00.000Z","ingest_ts":"2024-01-15T11:05:00.000Z"}
+{"id":"c-002","name":"bob_corrected","operation":"UPDATE","event_ts":"2024-01-15T11:30:00.000Z","ingest_ts":"2024-01-15T14:00:00.000Z"}

--- a/integration_tests/resources/data/bitemporal/ddl/customers_cdc.ddl
+++ b/integration_tests/resources/data/bitemporal/ddl/customers_cdc.ddl
@@ -1,0 +1,1 @@
+id STRING, name STRING, operation STRING, event_ts TIMESTAMP, ingest_ts TIMESTAMP

--- a/integration_tests/run_integration_tests.py
+++ b/integration_tests/run_integration_tests.py
@@ -219,6 +219,15 @@ class SDPMetaRunnerConf:
         "integration_tests/conf/json/multi-source-cdc-onboarding.template"
     )
 
+    # bitemporal AUTO CDC info (issue #359): one bronze CDC source with
+    # ``scd_type: bitemporal`` + ``system_sequence_by``. The seed file
+    # contains a late-arriving correction so validation can assert both
+    # time axes (business and system) on the target. Bronze-only: the
+    # minimal 3-task workflow (onboard -> bronze -> validate).
+    bitemporal_template: str = (
+        "integration_tests/conf/json/bitemporal-onboarding.template"
+    )
+
     def __post_init__(self):
         """Adjust onboarding file paths based on the requested file format."""
         fmt = (self.onboarding_file_format or "json").lower()
@@ -244,6 +253,7 @@ class SDPMetaRunnerConf:
             self.multi_source_cdc_template = self._to_yaml_variant(
                 self.multi_source_cdc_template
             )
+            self.bitemporal_template = self._to_yaml_variant(self.bitemporal_template)
             if self.onboarding_fanout_templates:
                 self.onboarding_fanout_templates = self._to_yaml_variant(
                     self.onboarding_fanout_templates
@@ -368,13 +378,14 @@ class SDPMETARunner:
             "multi_source_cdc": (
                 "./integration_tests/notebooks/multi_source_cdc_runners/"
             ),
+            "bitemporal": "./integration_tests/notebooks/bitemporal_runners/",
         }
         try:
             runner_conf.runners_full_local_path = source_paths[runner_conf.source]
         except KeyError:
             raise Exception(
                 "Given source is not supported. Supported sources are: "
-                "cloudfiles, eventhub, kafka, snapshot, multi_source_cdc"
+                "cloudfiles, eventhub, kafka, snapshot, multi_source_cdc, bitemporal"
             )
 
         return runner_conf
@@ -465,7 +476,11 @@ class SDPMETARunner:
             jobs.JobEnvironment(
                 environment_key="dl_meta_int_env",
                 spec=compute.Environment(
-                    client="1",
+                    # Serverless environment version. "1" is rejected by newer
+                    # workspaces (e.g. Free Edition: "Workspace doesn't support
+                    # Client-1 channel for REPL"); "2" is the current GA
+                    # environment version.
+                    client="2",
                     dependencies=[runner_conf.remote_whl_path],
                 ),
             )
@@ -533,7 +548,7 @@ class SDPMETARunner:
                             else (
                                 "setup_sdp_meta_pipeline_spec"
                                 if runner_conf.source
-                                in ("snapshot", "multi_source_cdc")
+                                in ("snapshot", "multi_source_cdc", "bitemporal")
                                 else "publish_events"
                             )
                         )
@@ -759,6 +774,12 @@ class SDPMETARunner:
             # 3-task shape: setup -> sdp-meta-pipeline -> validate. No
             # A2 step, no publish_events (seed JSON is already on volume).
             pass
+        elif runner_conf.source == "bitemporal":
+            # Bitemporal AUTO CDC (issue #359): bronze-only, seed JSON is
+            # already on the volume, so no publish_events / upload step and
+            # no silver pipeline. Minimal 3-task workflow: setup ->
+            # bronze_dlt_pipeline -> validate.
+            pass
         else:
             if runner_conf.source == "eventhub":
                 base_parameters = {
@@ -899,6 +920,8 @@ class SDPMETARunner:
             template_path = runner_conf.snapshot_template
         elif runner_conf.source == "multi_source_cdc":
             template_path = runner_conf.multi_source_cdc_template
+        elif runner_conf.source == "bitemporal":
+            template_path = runner_conf.bitemporal_template
 
         if template_path:
             onboard_text = self._read_template_text(template_path)
@@ -1280,10 +1303,11 @@ def process_arguments() -> dict[str:str]:
         ],
         [
             "source",
-            "Provide source type: cloudfiles, eventhub, kafka, snapshot, multi_source_cdc",
+            "Provide source type: cloudfiles, eventhub, kafka, snapshot, "
+            "multi_source_cdc, bitemporal",
             str.lower,
             False,
-            ["cloudfiles", "eventhub", "kafka", "snapshot", "multi_source_cdc"],
+            ["cloudfiles", "eventhub", "kafka", "snapshot", "multi_source_cdc", "bitemporal"],
         ],
         [
             "onboarding_file_format",

--- a/src/databricks/labs/sdp_meta/dataflow_pipeline.py
+++ b/src/databricks/labs/sdp_meta/dataflow_pipeline.py
@@ -819,6 +819,13 @@ class DataflowPipeline:
             sequence_cols = [col.strip() for col in sequence_by.split(',')]
             sequence_by = struct(*sequence_cols)  # Use struct() from pyspark.sql.functions
 
+        # system_sequence_by (bitemporal, Beta) is passed only when set:
+        # runtimes that predate the parameter reject the kwarg even as None,
+        # so existing SCD 1/2 flows must not see it (issue #359).
+        optional_cdc_kwargs = {}
+        if cdc_apply_changes.system_sequence_by:
+            optional_cdc_kwargs["system_sequence_by"] = cdc_apply_changes.system_sequence_by
+
         dp.create_auto_cdc_flow(
             target=target_table,
             source=self.view_name,
@@ -836,7 +843,8 @@ class DataflowPipeline:
             flow_name=cdc_apply_changes.flow_name,
             once=cdc_apply_changes.once,
             ignore_null_updates_column_list=cdc_apply_changes.ignore_null_updates_column_list,
-            ignore_null_updates_except_column_list=cdc_apply_changes.ignore_null_updates_except_column_list
+            ignore_null_updates_except_column_list=cdc_apply_changes.ignore_null_updates_except_column_list,
+            **optional_cdc_kwargs
         )
 
     def cdc_apply_changes_flows(self):

--- a/src/databricks/labs/sdp_meta/dataflow_spec.py
+++ b/src/databricks/labs/sdp_meta/dataflow_spec.py
@@ -150,6 +150,7 @@ class CDCApplyChanges:
     once: bool
     ignore_null_updates_column_list: list
     ignore_null_updates_except_column_list: list
+    system_sequence_by: str
 
 
 @dataclass
@@ -249,7 +250,8 @@ class DataflowSpecUtils:
         "flow_name",
         "once",
         "ignore_null_updates_column_list",
-        "ignore_null_updates_except_column_list"
+        "ignore_null_updates_except_column_list",
+        "system_sequence_by"
     ]
 
     cdc_applychanges_api_attributes_defaults = {
@@ -264,7 +266,8 @@ class DataflowSpecUtils:
         "flow_name": None,
         "once": False,
         "ignore_null_updates_column_list": None,
-        "ignore_null_updates_except_column_list": None
+        "ignore_null_updates_except_column_list": None,
+        "system_sequence_by": None
     }
 
     append_flow_mandatory_attributes = ["name", "source_format", "create_streaming_table", "source_details"]
@@ -343,7 +346,7 @@ class DataflowSpecUtils:
         "rowFilter",
         "quarantineRowFilter",
     ]
-    additional_cdc_apply_changes_columns = ["flow_name", "once"]
+    additional_cdc_apply_changes_columns = ["flow_name", "once", "system_sequence_by"]
     apply_changes_from_snapshot_api_attributes = [
         "keys",
         "scd_type",
@@ -560,6 +563,23 @@ class DataflowSpecUtils:
             json_cdc_apply_changes,
             DataflowSpecUtils.additional_cdc_apply_changes_columns
         )
+        # ``system_sequence_by`` and ``scd_type: "bitemporal"`` only make
+        # sense together (issue #359): the runtime requires a system-time
+        # column for bitemporal targets, and silently ignores the column on
+        # SCD 1/2 — rejecting the mismatch here surfaces it at onboarding
+        # instead of as a wrong table downstream (same failure class as
+        # issue #370).
+        scd_type = json_cdc_apply_changes.get("scd_type")
+        system_sequence_by = json_cdc_apply_changes.get("system_sequence_by")
+        if scd_type == "bitemporal" and not system_sequence_by:
+            raise Exception(
+                "scd_type 'bitemporal' requires system_sequence_by (the column holding "
+                "the system time at which each CDC event became known)"
+            )
+        if system_sequence_by and scd_type != "bitemporal":
+            raise Exception(
+                f"system_sequence_by is only supported with scd_type 'bitemporal', got scd_type {scd_type!r}"
+            )
         return CDCApplyChanges(**json_cdc_apply_changes)
 
     @staticmethod

--- a/src/databricks/labs/sdp_meta/identifiers.py
+++ b/src/databricks/labs/sdp_meta/identifiers.py
@@ -46,8 +46,10 @@ SUPPORTED_SOURCE_FORMATS = frozenset(
 # DLT requires the value as a string ("1" or "2"); see
 # ``dlt.apply_changes(stored_as_scd_type=...)`` and the existing
 # ``cdc_apply_changes.scd_type == "2"`` comparison in
-# ``dataflow_pipeline.py``.
-SUPPORTED_SCD_TYPES = frozenset({"1", "2"})
+# ``dataflow_pipeline.py``. "bitemporal" (Beta) additionally requires
+# ``system_sequence_by`` — enforced in
+# ``DataflowSpecUtils.get_cdc_apply_changes`` (issue #359).
+SUPPORTED_SCD_TYPES = frozenset({"1", "2", "bitemporal"})
 
 
 def is_regular_identifier(name) -> bool:
@@ -250,7 +252,8 @@ def validate_source_format(value, *, kind: str = "source_format") -> str:
 
 
 def validate_scd_type(value, *, kind: str = "scd_type") -> str:
-    """Validate ``value`` is one of :data:`SUPPORTED_SCD_TYPES` (``"1"``/``"2"``).
+    """Validate ``value`` is one of :data:`SUPPORTED_SCD_TYPES`
+    (``"1"``/``"2"``/``"bitemporal"``).
 
     DLT's ``apply_changes`` / ``apply_changes_from_snapshot`` accept the
     SCD type as a string. Catching a typo (``"3"``, ``"scd_2"``, etc.)

--- a/tests/test_dataflow_pipeline.py
+++ b/tests/test_dataflow_pipeline.py
@@ -570,6 +570,64 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         with self.assertRaises(Exception):
             dlt_data_flow.cdc_apply_changes()
 
+    def _make_silver_cdc_pipeline(self, cdc_apply_changes_dict):
+        """Build a silver DataflowPipeline around ``cdc_apply_changes_dict``,
+        with the bronze source table materialized (same setup as
+        test_cdc_apply_changes_scd_type2)."""
+        silver_dataflow_spec = SilverDataflowSpec(**DataflowPipelineTests.silver_dataflow_spec_map)
+        silver_dataflow_spec.cdcApplyChanges = json.dumps(cdc_apply_changes_dict)
+        self.spark.sql("CREATE DATABASE IF NOT EXISTS bronze")
+        self.spark.sql("DROP TABLE IF EXISTS bronze.customer")
+        if os.path.exists(f"{self.temp_delta_tables_path}/tables/customer"):
+            shutil.rmtree(f"{self.temp_delta_tables_path}/tables/customer")
+        options = {"rescuedDataColumn": "_rescued_data", "inferColumnTypes": "true", "multiline": True}
+        customers_parquet_df = self.spark.read.options(**options).json("tests/resources/data/customers")
+        (customers_parquet_df.withColumn("_rescued_data", lit("Test")).write.format("delta")
+            .mode("append").option("path", f"{self.temp_delta_tables_path}/tables/customer")
+            .saveAsTable("bronze.customer")
+         )
+        return DataflowPipeline(
+            self.spark,
+            silver_dataflow_spec,
+            f"{silver_dataflow_spec.targetDetails['table']}_inputview",
+            None,
+        )
+
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
+    def test_cdc_apply_changes_bitemporal_passes_system_sequence_by(
+            self, mock_create_streaming_table, mock_dlt):
+        """scd_type 'bitemporal' forwards system_sequence_by to
+        create_auto_cdc_flow (issue #359)."""
+        mock_create_streaming_table.return_value = None
+        mock_dlt.create_auto_cdc_flow = MagicMock(return_value=None)
+        dlt_data_flow = self._make_silver_cdc_pipeline({
+            "keys": ["id"],
+            "sequence_by": "operation_date",
+            "scd_type": "bitemporal",
+            "system_sequence_by": "ingest_ts",
+            "except_column_list": ["operation", "operation_date", "_rescued_data"],
+        })
+        dlt_data_flow.cdc_apply_changes()
+        _, kwargs = mock_dlt.create_auto_cdc_flow.call_args
+        self.assertEqual(kwargs["stored_as_scd_type"], "bitemporal")
+        self.assertEqual(kwargs["system_sequence_by"], "ingest_ts")
+
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
+    def test_cdc_apply_changes_scd1_omits_system_sequence_by(
+            self, mock_create_streaming_table, mock_dlt):
+        """SCD 1/2 flows must not see the system_sequence_by kwarg at all —
+        runtimes that predate the parameter reject it even as None
+        (issue #359)."""
+        mock_create_streaming_table.return_value = None
+        mock_dlt.create_auto_cdc_flow = MagicMock(return_value=None)
+        dlt_data_flow = self._make_silver_cdc_pipeline(self.silver_cdc_apply_changes)
+        dlt_data_flow.cdc_apply_changes()
+        _, kwargs = mock_dlt.create_auto_cdc_flow.call_args
+        self.assertEqual(kwargs["stored_as_scd_type"], "1")
+        self.assertNotIn("system_sequence_by", kwargs)
+
     @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dlt_view_bronze_call(self, mock_dlt):
         mock_dlt.temporary_view = MagicMock(return_value=None)

--- a/tests/test_dataflow_spec.py
+++ b/tests/test_dataflow_spec.py
@@ -321,6 +321,37 @@ class DataFlowSpecTests(SDPFrameworkTestCase):
         acfs = DataflowSpecUtils.get_apply_changes_from_snapshot(legacy_payload)
         self.assertEqual(acfs.scd_type, "1")
 
+    def test_getCdcApplyChanges_bitemporal_positive(self):
+        """scd_type 'bitemporal' with system_sequence_by parses (issue #359);
+        payloads without the field default it to None (backward compat with
+        specs written before the field existed)."""
+        payload = (
+            """{"keys" : ["playerId"], "sequence_by" : "eventTs", """
+            """"scd_type" : "bitemporal", "system_sequence_by" : "ingestTs"}"""
+        )
+        cdcApplyChanges = DataflowSpecUtils.get_cdc_apply_changes(payload)
+        self.assertEqual(cdcApplyChanges.scd_type, "bitemporal")
+        self.assertEqual(cdcApplyChanges.system_sequence_by, "ingestTs")
+        scd1_payload = """{"keys" : ["playerId"],"sequence_by" : "sequenceNum", "scd_type" : "1"}"""
+        self.assertIsNone(DataflowSpecUtils.get_cdc_apply_changes(scd1_payload).system_sequence_by)
+
+    def test_getCdcApplyChanges_bitemporal_requires_system_sequence_by(self):
+        """Bitemporal targets need a system-time column; missing it must fail
+        at parse time, not as an opaque runtime error."""
+        payload = """{"keys" : ["playerId"], "sequence_by" : "eventTs", "scd_type" : "bitemporal"}"""
+        with self.assertRaisesRegex(Exception, "system_sequence_by"):
+            DataflowSpecUtils.get_cdc_apply_changes(payload)
+
+    def test_getCdcApplyChanges_system_sequence_by_requires_bitemporal(self):
+        """system_sequence_by on SCD 1/2 would be silently ignored by the
+        runtime; reject the mismatch (same failure class as issue #370)."""
+        payload = (
+            """{"keys" : ["playerId"], "sequence_by" : "eventTs", """
+            """"scd_type" : "1", "system_sequence_by" : "ingestTs"}"""
+        )
+        with self.assertRaisesRegex(Exception, "bitemporal"):
+            DataflowSpecUtils.get_cdc_apply_changes(payload)
+
     def test_get_append_flow_positive(self):
         append_flow_spec = """[{
             "name":"customer_bronze_flow1",

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -300,13 +300,16 @@ class ValidateScdTypeTests(unittest.TestCase):
     compatibility with v0.0.10 onboarding files (issue #370)."""
 
     def test_supported_set_matches_expected(self):
-        self.assertEqual(SUPPORTED_SCD_TYPES, frozenset({"1", "2"}))
+        self.assertEqual(SUPPORTED_SCD_TYPES, frozenset({"1", "2", "bitemporal"}))
 
     def test_one_accepted(self):
         self.assertEqual(validate_scd_type("1"), "1")
 
     def test_two_accepted(self):
         self.assertEqual(validate_scd_type("2"), "2")
+
+    def test_bitemporal_accepted(self):
+        self.assertEqual(validate_scd_type("bitemporal"), "bitemporal")
 
     def test_int_one_coerced_to_string(self):
         # v0.0.10 onboarding files carried ``"scd_type": 1`` (issue #370).


### PR DESCRIPTION
Recreates #421 against the `issue_359` branch per maintainer guidance (external PRs do not target `main`).

Closes #359

**What:** `cdc_apply_changes` now accepts `scd_type: "bitemporal"` (Beta) with a new `system_sequence_by` attribute, forwarded to `create_auto_cdc_flow` so targets track history across both business time (`sequence_by`) and system time.

**Design notes:**
- Pairing is validated at parse time: bitemporal requires `system_sequence_by`; SCD 1/2 rejects it rather than silently ignoring it (same failure class as #370).
- The kwarg is passed to `create_auto_cdc_flow` only when configured, so existing SCD 1/2 flows are byte-identical in behavior on runtime channels that predate the parameter.
- `system_sequence_by` is registered in the backward-compat column list, so spec tables written by older versions parse unchanged.
- Scope: the single-flow CDC path (bronze + silver). Multi-source flow groups and the snapshot path can follow the same recipe if wanted.

**Testing:**
- Unit: spec parsing (defaults, both validation errors), pipeline tests asserting the kwarg is passed for bitemporal and absent otherwise; full suite passes.
- Integration: new `--source=bitemporal` scenario — one bronze CDC source seeded with a late-arriving correction (business time 11:30, ingested 14:00); validates the four generated columns (`__START_AT`/`__END_AT`/`__SYSTEM_START_AT`/`__SYSTEM_END_AT`), version-row totals, current rows on both time axes, an as-of-system-time query returning the pre-correction belief, and the rewritten history row. **Verified end-to-end on a serverless workspace — all assertions pass.**
- Scale validation: 1,000 generated CDC events (200 keys, Pareto-skewed version counts up to ~120 per key, 7% late arrivals of 2–10h) run through the same `create_auto_cdc_flow` call and compared **row-for-row** against a reference implementation of the observed bitemporal semantics — all 1,746 output rows matched exactly (1.75x row amplification over input events).
- One observation from deriving that reference model, possibly useful for the docs: within a single micro-batch the engine works off the final business timeline per key — a version whose successor is ingested after it gets a belief row (closed at the successor's ingest) plus its refined window, while a version whose successor was already known gets a single row; intermediate splits are collapsed. Full belief-replay behavior (as documented for bitemporal) appears across micro-batches. The integration scenario's assertions are consistent with both.
- Side fix: the harness's serverless jobs environment bumped from client "1" to "2"; newer workspaces reject version 1 ("Workspace doesn't support Client-1 channel for REPL").

Docs updated: CDC guide (new SCD type, field table, bitemporal example, Beta note), integration-tests README (run instructions + template translation table), CHANGELOG.

